### PR TITLE
Merge sfrinaldi/git.rst fix into u/ssabhlok/git_release_guide

### DIFF
--- a/source/git/git.rst
+++ b/source/git/git.rst
@@ -6,6 +6,7 @@ Git
 
    git-flow-guide
    pull_request_checklist
+   git_package_release_guide
    ssh_key_tutorial
    Git_LFS_Guide
    uasal_lfs


### PR DESCRIPTION
Applying fix for the ci failure / didn't want to edit branch directly in case being used actively still. 